### PR TITLE
feat(io,harmonic): consolidate converters, add SPHARM-PDM bridge, convert SHA to real SH

### DIFF
--- a/doc/api/io.md
+++ b/doc/api/io.md
@@ -65,6 +65,8 @@
 
    io.nef_to_efa_coeffs
    io.efa_coeffs_to_nef
+   io.spharmpdm_to_sha_coeffs
+   io.sha_coeffs_to_spharmpdm
    io.convert_coords_df_to_list
    io.convert_coords_df_to_df_sklearn_transform
 ```

--- a/doc/explanation/index.md
+++ b/doc/explanation/index.md
@@ -32,6 +32,15 @@ Conceptual explanations of morphometric methods and theory.
     harmonic
 ```
 
+## I/O
+
+```{eval-rst}
+.. toctree::
+    :maxdepth: 1
+
+    io
+```
+
 ## Visualization
 
 ```{eval-rst}

--- a/doc/explanation/io.md
+++ b/doc/explanation/io.md
@@ -1,0 +1,76 @@
+(io)=
+
+# I/O and format conversion
+
+The `ktch.io` module handles reading and writing morphometrics file formats and converting between file-format representations and analysis-ready data structures.
+
+## Module structure
+
+The module provides:
+
+- Readers and writers (`read_tps`, `write_nef`, etc.) that parse or serialize specific file formats
+- Data containers (`NefData`, `SpharmPdmData`, etc.) that hold parsed data in a format-faithful representation
+- Converter functions that bridge between file-format containers and the coefficient formats used by analysis classes
+
+Readers, writers, and data containers are organized by file format. Converters are in a single internal module (`_converters.py`) for discoverability.
+
+## Converters
+
+Bridge converters translate between a data container and the flat coefficient array that a `ktch.harmonic` transformer produces or consumes:
+
+```python
+from ktch.io import (
+    nef_to_efa_coeffs, efa_coeffs_to_nef,           # NEF <-> EFA
+    spharmpdm_to_sha_coeffs, sha_coeffs_to_spharmpdm,  # SPHARM-PDM <-> SHA
+)
+```
+
+Each pair follows the naming pattern `{format}_to_{tool}_coeffs` / `{tool}_coeffs_to_{format}`, where `format` refers to the file format and `tool` refers to the analysis class.
+
+A typical workflow:
+
+```python
+from ktch.io import read_spharmpdm_coef, spharmpdm_to_sha_coeffs
+from ktch.harmonic import SphericalHarmonicAnalysis
+
+# Read file -> data container -> analysis-ready coefficients
+data = read_spharmpdm_coef("specimen.coef")
+sha_coeffs = spharmpdm_to_sha_coeffs(data)
+
+# Reconstruct surface
+sha = SphericalHarmonicAnalysis(n_harmonics=data.l_max)
+surface = sha.inverse_transform(sha_coeffs.reshape(1, 3, -1))
+```
+
+Two utility functions convert coordinate DataFrames (from `read_tps` or `read_chc` with `as_frame=True`) into formats suitable for analysis: `convert_coords_df_to_list` produces a list of per-specimen arrays, and `convert_coords_df_to_df_sklearn_transform` produces a wide DataFrame compatible with sklearn transformers.
+
+Low-level format packing and unpacking functions (e.g., converting between SPHARM-PDM's interleaved storage layout and a structured coefficient list) are private (`_` prefix) and not part of the public API. Bridge converters call them internally, so users do not need to interact with them directly.
+
+## Data containers
+
+Each file format has a corresponding dataclass that holds parsed data:
+
+| Container | File format | Content |
+|---|---|---|
+| `NefData` | `.nef` | Normalized elliptic Fourier descriptors |
+| `ChainCodeData` | `.chc` | Freeman chain codes |
+| `TPSData` | `.tps` | Landmark coordinates |
+| `SpharmPdmData` | `.coef` | SPHARM-PDM spherical harmonic coefficients |
+
+All containers implement the `MorphoData` protocol, providing `to_numpy()`, `to_dataframe()`, and the `__array__` interface.
+
+Data containers store coefficients in a representation faithful to the file format. For example, `SpharmPdmData.coeffs` uses complex-valued arrays reflecting the SPHARM-PDM convention, even though `SphericalHarmonicAnalysis` internally uses real spherical harmonics. The bridge converter handles the basis conversion.
+
+## Separation from analysis modules
+
+Converter functions live in `ktch.io`, not in the analysis modules (`ktch.harmonic`, `ktch.landmark`, etc.). The `io` module does not import from any analysis module, and analysis modules do not import from `io`.
+
+This separation follows the ports-and-adapters pattern. Each analysis module defines its own input/output interface (the "port") — for example, `SphericalHarmonicAnalysis` expects a flat float64 coefficient array, and `GeneralizedProcrustesAnalysis` expects a list of coordinate arrays. The `io` module provides adapters that translate between external file formats and these interfaces. File-format details do not leak into the analysis modules, and analysis modules do not need to know about any particular file format.
+
+When a bridge converter requires domain-specific logic (e.g., complex-to-real spherical harmonic basis conversion for SPHARM-PDM), the formulas are implemented locally in `_converters.py` rather than imported from the analysis module. This avoids circular dependencies and keeps the modules independently testable.
+
+```{seealso}
+- {doc}`harmonic` for background on harmonic analysis methods
+- {doc}`../api/io` for API reference
+- {doc}`../how-to/data/load_spharm` for loading SPHARM-PDM data
+```

--- a/doc/tutorials/harmonic/spharm.md
+++ b/doc/tutorials/harmonic/spharm.md
@@ -183,7 +183,7 @@ X_coords = spharm_analysis.inverse_transform(X_transform.reshape(1, 3, -1))
 ```
 
 ```{code-cell} ipython3
-x_sph, y_sph, z_sph = np.real(X_coords[0].T)
+x_sph, y_sph, z_sph = X_coords[0].T
 
 fig = go.Figure(
     data=[
@@ -226,7 +226,7 @@ This demonstrates that the original shape is well reproduced.
 I, J, K = arr_surf_faces.T
 x_surf, y_surf, z_surf = arr_surf.T
 
-x_sph, y_sph, z_sph = np.real(X_coords[0].T)
+x_sph, y_sph, z_sph = X_coords[0].T
 
 
 fig = go.Figure(

--- a/ktch/harmonic/_spherical_harmonic_analysis.py
+++ b/ktch/harmonic/_spherical_harmonic_analysis.py
@@ -53,34 +53,23 @@ class SphericalHarmonicAnalysis(
     -----
     [Ritche_Kemp_1999]_, [Shen_etal_2009]_
 
-    .. math::
-        \begin{align}
-            \mathbf{p}(\theta, \phi) = \sum_{l=0}^{L} \sum_{m=-l}^l
-            \left(
-                c_l^m Y_l^m(\theta, \phi)
-            \right)
-        \end{align}
-
-    , where :math:`Y_l^m(\theta, \phi)` are spherical harmonics:
+    A surface point :math:`\mathbf{p}(\theta, \phi)` is expanded as
 
     .. math::
-        \begin{align}
-            Y_l^m(\theta, \phi) = \sqrt{\frac{2l+1}{4\pi}\frac{(l-m)!}{(l+m)!}} P_l^m(\cos(\theta)) e^{im\phi}
-        \end{align}
+        \mathbf{p}(\theta, \phi) = \sum_{l=0}^{L} \sum_{m=-l}^l
+            a_l^m \, S_l^m(\theta, \phi)
 
-    , where :math:`P_n^m(x)` are associated Legendre polynomials:
+    where :math:`S_l^m` are real orthonormal spherical harmonics defined
+    in terms of the complex harmonics :math:`Y_l^m`:
 
-    .. math::
+    * :math:`S_l^0 = Y_l^0`
+    * :math:`S_l^m = \sqrt{2}\,(-1)^m\,\mathrm{Re}(Y_l^m)` for :math:`m > 0`
+    * :math:`S_l^m = \sqrt{2}\,(-1)^{|m|}\,\mathrm{Im}(Y_l^{|m|})` for :math:`m < 0`
 
-        \begin{align}
-            P_n^m(x) = (-1)^m (1-x^2)^{\frac{m}{2}} \frac{d^m}{dx^m} P_n(x)
-        \end{align}
-
-    , where :math:`P_n(x)` are Legendre polynomials, which are solutions of Legendre’s differential equation;
-
-    .. math::
-        (1-x^2)\frac{d^2 y}{dx^2} -2x \frac{dy}{dx} + n(n+1)y = 0.
-
+    The coefficients :math:`a_l^m` are real-valued, so ``transform``
+    returns a ``float64`` array.  Conversion utilities
+    ``_complex_to_real_sph_coef`` and ``_real_to_complex_sph_coef`` are
+    available for interoperability with complex-basis representations.
 
     References
     ----------
@@ -140,20 +129,20 @@ class SphericalHarmonicAnalysis(
         return self.fit(X, y).transform(X, theta_phi=theta_phi)
 
     def _transform_single(self, X, theta_phi):
-        """Compute SPHARM coefficients for a single sample.
+        """Compute real SPHARM coefficients for a single sample.
 
         Parameters
         ----------
-        X: array-like of shape (n_coords, n_dim)
-                Coordinate values of a surface.
-
-        theta_phi: array-like of shape (n_coords,2)
-                Parameters indicating the position on the surface.
+        X : array-like of shape (n_coords, 3)
+            Coordinate values of a surface.
+        theta_phi : array-like of shape (n_coords, 2)
+            Parameters indicating the position on the surface.
 
         Returns
         -------
-        X_transformed: array-like
-            Returns the SPHARM coefficients.
+        X_transformed : ndarray of shape (3 * (l_max + 1)**2,), float64
+            Flat real-valued SPHARM coefficient vector.
+            Layout: ``[cx_0_0, ..., cy_0_0, ..., cz_0_0, ...]``.
         """
         l_max = self.n_harmonics
         theta = theta_phi[:, 0]
@@ -171,14 +160,10 @@ class SphericalHarmonicAnalysis(
                 stacklevel=2,
             )
 
-        lm2j = np.array([[l, m] for l in range(l_max + 1) for m in range(-l, l + 1)])
+        B = _real_sph_harm_basis_matrix(l_max, theta, phi)
 
-        A_Mat = np.array([sp.special.sph_harm_y(l, m, theta, phi) for l, m in lm2j])
-
-        sol = sp.linalg.lstsq(A_Mat.T, X)
-        c_x, c_y, c_z = sol[0].T
-
-        X_transformed = np.concatenate([c_x, c_y, c_z], axis=-1)
+        sol = sp.linalg.lstsq(B, X)
+        X_transformed = sol[0].T.ravel()
 
         return X_transformed
 
@@ -349,6 +334,162 @@ class SphericalHarmonicAnalysis(
 ###########################################################
 
 
+def _real_sph_harm_y(
+    l: int,
+    m: int,
+    theta: npt.NDArray[np.float64],
+    phi: npt.NDArray[np.float64],
+) -> npt.NDArray[np.float64]:
+    r"""Evaluate a real spherical harmonic :math:`S_l^m`.
+
+    Defined via :func:`scipy.special.sph_harm_y`:
+
+    * :math:`m = 0`:  :math:`S_l^0 = Y_l^0`
+    * :math:`m > 0`:  :math:`S_l^m = \sqrt{2}\,(-1)^m\,\mathrm{Re}(Y_l^m)`
+    * :math:`m < 0`:  :math:`S_l^m = \sqrt{2}\,(-1)^{|m|}\,\mathrm{Im}(Y_l^{|m|})`
+
+    This evaluates to:
+
+    * :math:`S_l^m = \sqrt{2}\,N_l^m\,P_l^m(\cos\theta)\,\cos(m\varphi)`
+      for :math:`m > 0`
+    * :math:`S_l^{-|m|} = \sqrt{2}\,N_l^{|m|}\,P_l^{|m|}(\cos\theta)\,
+      \sin(|m|\varphi)` for :math:`m < 0`
+
+    The :math:`(-1)^m` factor cancels the Condon-Shortley phase
+    included in ``sph_harm_y``, yielding positive cosine/sine.
+    """
+    if m == 0:
+        return sp.special.sph_harm_y(l, 0, theta, phi).real
+    elif m > 0:
+        return np.sqrt(2) * (-1) ** m * np.real(sp.special.sph_harm_y(l, m, theta, phi))
+    else:
+        return np.sqrt(2) * (-1) ** abs(m) * np.imag(
+            sp.special.sph_harm_y(l, abs(m), theta, phi)
+        )
+
+
+def _real_sph_harm_basis_matrix(
+    l_max: int,
+    theta: npt.NDArray[np.float64],
+    phi: npt.NDArray[np.float64],
+) -> npt.NDArray[np.float64]:
+    r"""Build real-valued spherical harmonic design matrix.
+
+    Columns correspond to ``(l, m)`` pairs in the ordering
+    ``(0,0), (1,-1), (1,0), (1,1), (2,-2), ...``.
+
+    Parameters
+    ----------
+    l_max : int
+        Maximum degree.
+    theta : ndarray of shape (N,)
+        Polar angle (colatitude) values.
+    phi : ndarray of shape (N,)
+        Azimuthal angle values.
+
+    Returns
+    -------
+    ndarray of shape (N, (l_max+1)**2), float64
+        Real-valued design matrix.
+    """
+    n_pts = len(theta)
+    n_coeffs = (l_max + 1) ** 2
+    B = np.empty((n_pts, n_coeffs))
+
+    for l in range(l_max + 1):
+        for m in range(-l, l + 1):
+            idx = l**2 + l + m
+            B[:, idx] = _real_sph_harm_y(l, m, theta, phi)
+
+    return B
+
+
+def _complex_to_real_sph_coef(
+    coef_complex: npt.NDArray[np.complexfloating],
+) -> npt.NDArray[np.float64]:
+    r"""Convert complex SH coefficients to real SH coefficients.
+
+    Includes the :math:`(-1)^m` Condon-Shortley phase factor,
+    which makes this different from DHA's ``_complex_to_real_coef``.
+
+    The mapping for degree ``l``, order ``m`` is:
+
+    * ``m = 0``:  ``a_{l,0} = Re(c_{l,0})``
+    * ``m > 0``:  ``a_{l,m} = \sqrt{2}\,(-1)^m\,Re(c_{l,m})``
+    * ``m < 0``:  ``a_{l,m} = -\sqrt{2}\,(-1)^{|m|}\,Im(c_{l,|m|})``
+
+    Parameters
+    ----------
+    coef_complex : ndarray of shape ((l_max+1)**2,) or ((l_max+1)**2, D)
+        Complex coefficients in flat ordering.
+
+    Returns
+    -------
+    ndarray of same shape, float64
+        Real-valued coefficients.
+    """
+    coef_real = np.empty_like(coef_complex, dtype=np.float64)
+    n_coef = coef_complex.shape[0]
+    l_max = int(np.sqrt(n_coef)) - 1
+
+    for l in range(l_max + 1):
+        for m in range(-l, l + 1):
+            idx = l**2 + l + m
+            if m == 0:
+                coef_real[idx] = np.real(coef_complex[idx])
+            elif m > 0:
+                coef_real[idx] = np.sqrt(2) * (-1) ** m * np.real(coef_complex[idx])
+            else:
+                idx_pos = l**2 + l + (-m)
+                coef_real[idx] = -np.sqrt(2) * (-1) ** abs(m) * np.imag(
+                    coef_complex[idx_pos]
+                )
+
+    return coef_real
+
+
+def _real_to_complex_sph_coef(
+    coef_real: npt.NDArray[np.float64],
+) -> npt.NDArray[np.complexfloating]:
+    r"""Convert real SH coefficients to complex SH coefficients.
+
+    Inverse of :func:`_complex_to_real_sph_coef`.  The output satisfies
+    conjugate symmetry: ``c_{l,-m} = (-1)^m \overline{c_{l,m}}``.
+
+    Parameters
+    ----------
+    coef_real : ndarray of shape ((l_max+1)**2,) or ((l_max+1)**2, D)
+        Real-valued coefficients in flat ordering.
+
+    Returns
+    -------
+    ndarray of same shape, complex128
+        Complex coefficients.
+    """
+    coef_complex = np.empty_like(coef_real, dtype=np.complex128)
+    n_coef = coef_real.shape[0]
+    l_max = int(np.sqrt(n_coef)) - 1
+
+    for l in range(l_max + 1):
+        # m = 0
+        idx_0 = l**2 + l
+        coef_complex[idx_0] = coef_real[idx_0] + 0j
+
+        # m > 0 and corresponding m < 0
+        for m in range(1, l + 1):
+            idx_pos = l**2 + l + m
+            idx_neg = l**2 + l - m
+            c_pos = (
+                (-1) ** m
+                * (coef_real[idx_pos] - 1j * coef_real[idx_neg])
+                / np.sqrt(2)
+            )
+            coef_complex[idx_pos] = c_pos
+            coef_complex[idx_neg] = (-1) ** m * np.conj(c_pos)
+
+    return coef_complex
+
+
 def xyz2spherical(xyz: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
     """Convert Cartesian coordinates to spherical coordinates.
 
@@ -382,7 +523,6 @@ def spharm(
     coef: list[npt.ArrayLike],
     theta_range=None,
     phi_range=None,
-    threshold_imag_parts: float = 1e-10,
 ):
     """Reconstruct surface coordinates from SPHARM coefficients.
 
@@ -391,8 +531,8 @@ def spharm(
     l_max : int
         Maximum degree of spherical harmonics.
     coef : list of array-like
-        SPHARM coefficients. ``coef[l]`` has shape ``(2*l+1, 3)`` and
-        ``coef[l][l+m]`` holds ``(c_x, c_y, c_z)`` for degree ``l``
+        Real SPHARM coefficients. ``coef[l]`` has shape ``(2*l+1, 3)``
+        and ``coef[l][l+m]`` holds ``(c_x, c_y, c_z)`` for degree ``l``
         and order ``m``.
     theta_range : array-like of shape (n_theta,), optional
         Polar angle values (colatitude, 0 to pi). Defaults to
@@ -400,10 +540,6 @@ def spharm(
     phi_range : array-like of shape (n_phi,), optional
         Azimuthal angle values (0 to 2*pi). Defaults to
         ``np.linspace(0, 2*pi, 180)``.
-    threshold_imag_parts : float, default=1e-10
-        Tolerance for imaginary parts in the reconstructed coordinates.
-        A warning is issued if the total imaginary magnitude exceeds
-        this value.
 
     Returns
     -------
@@ -415,31 +551,20 @@ def spharm(
     if phi_range is None:
         phi_range = np.linspace(0, 2 * np.pi, 180)
 
-    l, m, theta, phi = np.meshgrid(
-        np.arange(0, l_max + 1, 1),
-        np.arange(-l_max, l_max + 1, 1),
-        theta_range,
-        phi_range,
-        indexing="ij",
-    )
+    theta_grid, phi_grid = np.meshgrid(theta_range, phi_range, indexing="ij")
+    B = _real_sph_harm_basis_matrix(l_max, theta_grid.ravel(), phi_grid.ravel())
 
-    c = np.array(
-        [np.pad(c_l, ((l_max - l, l_max - l), (0, 0))) for l, c_l in enumerate(coef)]
-    )
+    coef_matrix = np.vstack(
+        [coef[l] for l in range(l_max + 1)]
+    )  # ((l_max+1)^2, 3)
 
-    sph_mat = sp.special.sph_harm_y(l, m, theta, phi)
+    coords = B @ coef_matrix  # (N, 3)
+    n_theta = len(theta_range)
+    n_phi = len(phi_range)
 
-    coords = np.tensordot(c, sph_mat, axes=([0, 1], [0, 1]))
-
-    total_imag_parts = np.abs(np.imag(coords)).sum()
-    if total_imag_parts > threshold_imag_parts:
-        warnings.warn(
-            f"The coordinates have significant imaginary parts {total_imag_parts}.",
-            UserWarning,
-            stacklevel=2,
-        )
-
-    x, y, z = np.real(coords)
+    x = coords[:, 0].reshape(n_theta, n_phi)
+    y = coords[:, 1].reshape(n_theta, n_phi)
+    z = coords[:, 2].reshape(n_theta, n_phi)
     return x, y, z
 
 

--- a/ktch/harmonic/tests/test_spherical_harmonic_analysis.py
+++ b/ktch/harmonic/tests/test_spherical_harmonic_analysis.py
@@ -3,7 +3,12 @@ import pytest
 from numpy.testing import assert_allclose, assert_array_almost_equal
 
 from ktch.harmonic import SphericalHarmonicAnalysis, spharm, xyz2spherical
-from ktch.harmonic._spherical_harmonic_analysis import cvt_spharm_coef_to_list
+from ktch.harmonic._spherical_harmonic_analysis import (
+    _complex_to_real_sph_coef,
+    _real_sph_harm_basis_matrix,
+    _real_to_complex_sph_coef,
+    cvt_spharm_coef_to_list,
+)
 
 
 def test_xyz2spherical_axes():
@@ -88,23 +93,7 @@ def test_transform_and_inverse_roundtrip():
 
 def test_get_feature_names_out():
     l_max = 2
-    theta_range = np.linspace(0, np.pi, 5)
-    phi_range = np.linspace(0, 2 * np.pi, 9)
-
-    coef_list = [
-        np.array([[1.0, 0.2, -0.1]]),
-        np.zeros((3, 3)),
-        np.zeros((5, 3)),
-    ]
-
-    x, y, z = spharm(l_max, coef_list, theta_range=theta_range, phi_range=phi_range)
-    coords = np.stack([x, y, z], axis=-1).reshape(-1, 3)
-    theta_grid, phi_grid = np.meshgrid(theta_range, phi_range, indexing="ij")
-    theta_phi = np.stack([theta_grid.ravel(), phi_grid.ravel()], axis=-1)
-
-    sha = SphericalHarmonicAnalysis(n_harmonics=l_max, n_jobs=1)
-    sha.fit_transform([coords], theta_phi=[theta_phi])
-
+    sha = SphericalHarmonicAnalysis(n_harmonics=l_max)
     names = sha.get_feature_names_out()
     n_terms = (l_max + 1) ** 2
     assert len(names) == 3 * n_terms
@@ -135,91 +124,6 @@ def test_underdetermined_system_warns():
         sha.fit_transform([coords], theta_phi=[theta_phi])
 
 
-class TestNHarmonicsOneSHA:
-    """Tests for n_harmonics=1 (l_max=1) in SphericalHarmonicAnalysis.
-
-    l_max=1 produces (1+1)^2 = 4 coefficients per axis (12 total).
-    This is the minimum non-trivial harmonic count that includes both
-    the constant term (l=0) and the first-order dipole (l=1).
-
-    Test surfaces use parametric ellipsoids (exactly representable at
-    l_max=1) to avoid passing real-only coefficients to spharm(), which
-    would produce complex coordinates and trigger a UserWarning.
-    """
-
-    def test_shape(self):
-        """SHA with n_harmonics=1 produces output shape (1, 3*4) = (1, 12)."""
-        l_max = 1
-        n_terms = (l_max + 1) ** 2  # 4
-        theta_range = np.linspace(0.1, np.pi - 0.1, 6)
-        phi_range = np.linspace(0, 2 * np.pi, 12)
-        theta_grid, phi_grid = np.meshgrid(theta_range, phi_range, indexing="ij")
-
-        x = 1.0 * np.sin(theta_grid) * np.cos(phi_grid)
-        y = 0.5 * np.sin(theta_grid) * np.sin(phi_grid)
-        z = 0.3 * np.cos(theta_grid)
-
-        coords = np.stack([x, y, z], axis=-1).reshape(-1, 3)
-        theta_phi = np.stack([theta_grid.ravel(), phi_grid.ravel()], axis=-1)
-
-        sha = SphericalHarmonicAnalysis(n_harmonics=l_max, n_jobs=1)
-        transformed = sha.fit_transform([coords], theta_phi=[theta_phi])
-
-        assert transformed.shape == (1, 3 * n_terms)
-
-    def test_round_trip(self):
-        """SHA with n_harmonics=1: forward + inverse recovers the surface."""
-        l_max = 1
-        theta_range = np.linspace(0.1, np.pi - 0.1, 6)
-        phi_range = np.linspace(0, 2 * np.pi, 12)
-        theta_grid, phi_grid = np.meshgrid(theta_range, phi_range, indexing="ij")
-
-        x = 1.0 * np.sin(theta_grid) * np.cos(phi_grid)
-        y = 0.5 * np.sin(theta_grid) * np.sin(phi_grid)
-        z = 0.3 * np.cos(theta_grid)
-
-        coords = np.stack([x, y, z], axis=-1).reshape(-1, 3)
-        theta_phi = np.stack([theta_grid.ravel(), phi_grid.ravel()], axis=-1)
-
-        sha = SphericalHarmonicAnalysis(n_harmonics=l_max, n_jobs=1)
-        transformed = sha.fit_transform([coords], theta_phi=[theta_phi])
-
-        reconstructed = sha.inverse_transform(
-            transformed.reshape(1, 3, -1),
-            theta_range=theta_range,
-            phi_range=phi_range,
-        )
-
-        expected = np.stack([x, y, z], axis=-1)
-        assert reconstructed.shape == (1, len(theta_range), len(phi_range), 3)
-        assert_array_almost_equal(reconstructed[0], expected, decimal=5)
-
-    def test_feature_names(self):
-        """SHA with n_harmonics=1 produces correct feature names."""
-        l_max = 1
-        theta_range = np.linspace(0.1, np.pi - 0.1, 6)
-        phi_range = np.linspace(0, 2 * np.pi, 12)
-
-        coef_list = [
-            np.array([[1.0, 0.0, 0.0]]),
-            np.zeros((3, 3)),
-        ]
-
-        x, y, z = spharm(l_max, coef_list, theta_range=theta_range, phi_range=phi_range)
-        coords = np.stack([x, y, z], axis=-1).reshape(-1, 3)
-        theta_grid, phi_grid = np.meshgrid(theta_range, phi_range, indexing="ij")
-        theta_phi = np.stack([theta_grid.ravel(), phi_grid.ravel()], axis=-1)
-
-        sha = SphericalHarmonicAnalysis(n_harmonics=l_max, n_jobs=1)
-        sha.fit_transform([coords], theta_phi=[theta_phi])
-
-        names = sha.get_feature_names_out()
-        n_terms = (l_max + 1) ** 2  # 4
-        assert len(names) == 3 * n_terms
-        assert names[0] == "cx_0_0"
-        assert names[1] == "cx_1_-1"
-
-
 class TestXyz2SphericalDegenerate:
     """Tests for xyz2spherical with degenerate (pole) inputs."""
 
@@ -241,33 +145,35 @@ class TestXyz2SphericalDegenerate:
 
     def test_mixed_poles_and_equator(self):
         """Mix of poles and equatorial points all produce finite results."""
-        coords = np.array([
-            [0.0, 0.0, 1.0],   # north pole
-            [0.0, 0.0, -1.0],  # south pole
-            [1.0, 0.0, 0.0],   # equator x-axis
-            [0.0, 1.0, 0.0],   # equator y-axis
-        ])
+        coords = np.array(
+            [
+                [0.0, 0.0, 1.0],  # north pole
+                [0.0, 0.0, -1.0],  # south pole
+                [1.0, 0.0, 0.0],  # equator x-axis
+                [0.0, 1.0, 0.0],  # equator y-axis
+            ]
+        )
         result = xyz2spherical(coords)
         assert np.all(np.isfinite(result))
         assert result.shape == (4, 2)
         # Equatorial points
         assert result[2, 0] == pytest.approx(np.pi / 2)  # theta
-        assert result[2, 1] == pytest.approx(0.0)         # phi (x-axis)
+        assert result[2, 1] == pytest.approx(0.0)  # phi (x-axis)
         assert result[3, 0] == pytest.approx(np.pi / 2)  # theta
         assert result[3, 1] == pytest.approx(np.pi / 2)  # phi (y-axis)
 
     def test_near_pole(self):
         """Points very close to poles produce correct theta values."""
         eps = 1e-15
-        coords = np.array([
-            [eps, 0.0, 1.0],
-            [0.0, eps, -1.0],
-        ])
+        coords = np.array(
+            [
+                [eps, 0.0, 1.0],
+                [0.0, eps, -1.0],
+            ]
+        )
         result = xyz2spherical(coords)
         assert np.all(np.isfinite(result))
-        # Near north pole: theta ≈ 0
         assert result[0, 0] == pytest.approx(0.0, abs=1e-10)
-        # Near south pole: theta ≈ pi
         assert result[1, 0] == pytest.approx(np.pi, abs=1e-10)
 
 
@@ -276,18 +182,15 @@ class TestSHARoundTripMixedSpectrum:
 
     Uses an asymmetrically scaled ellipsoid with an axis-dependent offset,
     generating non-trivial content in both l=0, l=1, and l=2 harmonics.
-    The coordinate-level round-trip (coords -> coefficients -> inverse ->
-    coords) is the correct invariant.
     """
 
     def test_mixed_spectrum_round_trip(self):
-        """coords -> SHA -> inverse recovers the real-valued surface."""
+        """coords -> SHA -> inverse recovers the surface."""
         l_max = 2
         theta_range = np.linspace(0.1, np.pi - 0.1, 8)
         phi_range = np.linspace(0, 2 * np.pi, 16)
         theta_grid, phi_grid = np.meshgrid(theta_range, phi_range, indexing="ij")
 
-        # Asymmetric ellipsoid with offset
         x = 2.0 * np.sin(theta_grid) * np.cos(phi_grid) + 0.5
         y = 1.5 * np.sin(theta_grid) * np.sin(phi_grid) - 0.3
         z = 1.0 * np.cos(theta_grid) + 0.2
@@ -333,12 +236,9 @@ class TestSHAInverseTransformDefaults:
         sha = SphericalHarmonicAnalysis(n_harmonics=l_max, n_jobs=1)
         transformed = sha.fit_transform([coords], theta_phi=[theta_phi])
 
-        # Call without theta_range/phi_range -> uses defaults (90, 180)
         result = sha.inverse_transform(transformed.reshape(1, 3, -1))
         assert result.shape == (1, 90, 180, 3)
 
-        # Input has l=0 only (constant function), so the reconstructed
-        # surface should be approximately constant across the grid.
         for dim in range(3):
             surface = result[0, :, :, dim]
             assert np.std(surface) < 1e-5, (
@@ -348,27 +248,7 @@ class TestSHAInverseTransformDefaults:
 
 
 class TestSHANHarmonicsZero:
-    """Tests for n_harmonics=0 (l=0 only, constant function).
-
-    l_max=0 produces a single coefficient per axis (3 total).
-    The surface is a constant point in 3D space.
-    """
-
-    def test_shape(self):
-        """SHA with n_harmonics=0 produces output shape (1, 3)."""
-        theta_range = np.linspace(0.1, np.pi - 0.1, 10)
-        phi_range = np.linspace(0, 2 * np.pi, 20)
-
-        coef_list = [np.array([[1.0, 0.5, -0.2]])]
-        x, y, z = spharm(0, coef_list, theta_range=theta_range, phi_range=phi_range)
-        coords = np.stack([x, y, z], axis=-1).reshape(-1, 3)
-        theta_grid, phi_grid = np.meshgrid(theta_range, phi_range, indexing="ij")
-        theta_phi = np.stack([theta_grid.ravel(), phi_grid.ravel()], axis=-1)
-
-        sha = SphericalHarmonicAnalysis(n_harmonics=0, n_jobs=1)
-        transformed = sha.fit_transform([coords], theta_phi=[theta_phi])
-
-        assert transformed.shape == (1, 3)
+    """Tests for n_harmonics=0 (l=0 only, constant function)."""
 
     def test_coefficient_recovery(self):
         """SHA with n_harmonics=0 recovers the l=0 coefficient."""
@@ -384,7 +264,8 @@ class TestSHANHarmonicsZero:
         sha = SphericalHarmonicAnalysis(n_harmonics=0, n_jobs=1)
         transformed = sha.fit_transform([coords], theta_phi=[theta_phi])
 
-        assert_allclose(np.real(transformed[0]), coef_list[0][0], atol=1e-10)
+        assert transformed.shape == (1, 3)
+        assert_allclose(transformed[0], coef_list[0][0], atol=1e-10)
 
     def test_feature_names(self):
         """SHA with n_harmonics=0 produces 3 feature names."""
@@ -424,10 +305,12 @@ class TestSHANonFiniteInput:
 
     def test_nan_input_raises(self):
         """SHA with NaN in coordinates raises ValueError."""
-        theta_phi = np.column_stack([
-            np.linspace(0.1, np.pi - 0.1, 10),
-            np.linspace(0, 2 * np.pi, 10),
-        ])
+        theta_phi = np.column_stack(
+            [
+                np.linspace(0.1, np.pi - 0.1, 10),
+                np.linspace(0, 2 * np.pi, 10),
+            ]
+        )
         coords = np.ones((10, 3))
         coords[3, 0] = np.nan
 
@@ -437,13 +320,73 @@ class TestSHANonFiniteInput:
 
     def test_inf_input_raises(self):
         """SHA with Inf in coordinates raises ValueError."""
-        theta_phi = np.column_stack([
-            np.linspace(0.1, np.pi - 0.1, 10),
-            np.linspace(0, 2 * np.pi, 10),
-        ])
+        theta_phi = np.column_stack(
+            [
+                np.linspace(0.1, np.pi - 0.1, 10),
+                np.linspace(0, 2 * np.pi, 10),
+            ]
+        )
         coords = np.ones((10, 3))
         coords[5, 1] = np.inf
 
         sha = SphericalHarmonicAnalysis(n_harmonics=2, n_jobs=1)
         with pytest.raises(ValueError, match="infs or NaNs"):
             sha.fit_transform([coords], theta_phi=[theta_phi])
+
+
+#
+# Real spherical harmonic basis and coefficient conversion
+#
+
+
+class TestRealSHOrthonormality:
+    """Verify the real SH basis is orthonormal on the sphere."""
+
+    @pytest.mark.parametrize("l_max,n_theta,n_phi", [(2, 50, 100), (5, 80, 160)])
+    def test_orthonormality(self, l_max, n_theta, n_phi):
+        nodes, weights = np.polynomial.legendre.leggauss(n_theta)
+        theta_gl = np.arccos(nodes)
+        phi_uniform = np.linspace(0, 2 * np.pi, n_phi, endpoint=False)
+        dphi = 2 * np.pi / n_phi
+
+        theta_grid, phi_grid = np.meshgrid(theta_gl, phi_uniform, indexing="ij")
+        B = _real_sph_harm_basis_matrix(l_max, theta_grid.ravel(), phi_grid.ravel())
+        w_grid = np.outer(weights, np.full(n_phi, dphi)).ravel()
+        gram = B.T @ np.diag(w_grid) @ B
+
+        n_coeffs = (l_max + 1) ** 2
+        assert_allclose(gram, np.eye(n_coeffs), atol=1e-12)
+
+
+class TestComplexRealSphCoefRoundtrip:
+    """complex -> real -> complex and real -> complex -> real."""
+
+    def test_complex_to_real_to_complex(self):
+        rng = np.random.RandomState(99)
+        l_max = 4
+        n_coeffs = (l_max + 1) ** 2
+
+        coef_complex = np.zeros((n_coeffs, 3), dtype=np.complex128)
+        for l in range(l_max + 1):
+            idx_0 = l**2 + l
+            coef_complex[idx_0] = rng.randn(3)
+            for m in range(1, l + 1):
+                idx_pos = l**2 + l + m
+                idx_neg = l**2 + l - m
+                c = rng.randn(3) + 1j * rng.randn(3)
+                coef_complex[idx_pos] = c
+                coef_complex[idx_neg] = (-1) ** m * np.conj(c)
+
+        coef_real = _complex_to_real_sph_coef(coef_complex)
+        coef_complex_rt = _real_to_complex_sph_coef(coef_real)
+        assert_allclose(coef_complex_rt, coef_complex, atol=1e-14)
+
+    def test_real_to_complex_to_real(self):
+        rng = np.random.RandomState(77)
+        l_max = 4
+        n_coeffs = (l_max + 1) ** 2
+        coef_real = rng.randn(n_coeffs, 3)
+
+        coef_complex = _real_to_complex_sph_coef(coef_real)
+        coef_real_rt = _complex_to_real_sph_coef(coef_complex)
+        assert_allclose(coef_real_rt, coef_real, atol=1e-14)

--- a/ktch/io/__init__.py
+++ b/ktch/io/__init__.py
@@ -22,13 +22,13 @@ from ._converters import (
     convert_coords_df_to_list,
     efa_coeffs_to_nef,
     nef_to_efa_coeffs,
+    sha_coeffs_to_spharmpdm,
+    spharmpdm_to_sha_coeffs,
 )
 from ._nef import NefData, read_nef, write_nef
 from ._protocols import MorphoData, MorphoDataMixin
 from ._spharm_pdm import (
     SpharmPdmData,
-    cvt_spharm_coef_list_to_spharmpdm,
-    cvt_spharm_coef_spharmpdm_to_list,
     read_spharmpdm_coef,
 )
 from ._tps import TPSData, read_tps, write_tps
@@ -46,8 +46,6 @@ __all__ = [
     "read_tps",
     "write_tps",
     "read_spharmpdm_coef",
-    "cvt_spharm_coef_spharmpdm_to_list",
-    "cvt_spharm_coef_list_to_spharmpdm",
     "read_chc",
     "write_chc",
     "read_nef",
@@ -55,6 +53,8 @@ __all__ = [
     # Converter functions
     "nef_to_efa_coeffs",
     "efa_coeffs_to_nef",
+    "spharmpdm_to_sha_coeffs",
+    "sha_coeffs_to_spharmpdm",
     "convert_coords_df_to_list",
     "convert_coords_df_to_df_sklearn_transform",
 ]

--- a/ktch/io/_converters.py
+++ b/ktch/io/_converters.py
@@ -143,6 +143,322 @@ def efa_coeffs_to_nef(coeffs, specimen_names=None, n_dim=2):
 
 
 #
+# SPHARM-PDM <-> SHA coefficient
+#
+# The following helpers convert between complex and real SH coefficient
+# representations.  They duplicate the logic in
+# ``ktch.harmonic._spherical_harmonic_analysis`` so that the io module
+# does not depend on the harmonic module.
+#
+
+
+def _complex_to_real_sph_coef(coef_complex):
+    """Convert complex SH coefficients to real SH coefficients.
+
+    Includes the ``(-1)^m`` Condon-Shortley phase factor.
+    """
+    coef_real = np.empty_like(coef_complex, dtype=np.float64)
+    n_coef = coef_complex.shape[0]
+    l_max = int(np.sqrt(n_coef)) - 1
+
+    for l in range(l_max + 1):
+        for m in range(-l, l + 1):
+            idx = l**2 + l + m
+            if m == 0:
+                coef_real[idx] = np.real(coef_complex[idx])
+            elif m > 0:
+                coef_real[idx] = np.sqrt(2) * (-1) ** m * np.real(coef_complex[idx])
+            else:
+                idx_pos = l**2 + l + (-m)
+                coef_real[idx] = -np.sqrt(2) * (-1) ** abs(m) * np.imag(
+                    coef_complex[idx_pos]
+                )
+
+    return coef_real
+
+
+def _real_to_complex_sph_coef(coef_real):
+    """Convert real SH coefficients to complex SH coefficients.
+
+    Inverse of ``_complex_to_real_sph_coef``.
+    """
+    coef_complex = np.empty_like(coef_real, dtype=np.complex128)
+    n_coef = coef_real.shape[0]
+    l_max = int(np.sqrt(n_coef)) - 1
+
+    for l in range(l_max + 1):
+        idx_0 = l**2 + l
+        coef_complex[idx_0] = coef_real[idx_0] + 0j
+
+        for m in range(1, l + 1):
+            idx_pos = l**2 + l + m
+            idx_neg = l**2 + l - m
+            c_pos = (
+                (-1) ** m
+                * (coef_real[idx_pos] - 1j * coef_real[idx_neg])
+                / np.sqrt(2)
+            )
+            coef_complex[idx_pos] = c_pos
+            coef_complex[idx_neg] = (-1) ** m * np.conj(c_pos)
+
+    return coef_complex
+
+
+def spharmpdm_to_sha_coeffs(spharmpdm_data):
+    """Convert SpharmPdmData to SHA-compatible flat coefficient vectors.
+
+    The output contains real-valued coefficients with respect to the
+    standard orthonormal real spherical harmonic basis used by
+    :class:`~ktch.harmonic.SphericalHarmonicAnalysis`.
+
+    Parameters
+    ----------
+    spharmpdm_data : SpharmPdmData or list of SpharmPdmData
+        SPHARM-PDM data read by :func:`read_spharmpdm_coef`.
+
+    Returns
+    -------
+    coeffs : np.ndarray of shape (n_samples, 3 * (l_max + 1)**2), float64
+        Flat coefficient vectors compatible with
+        :meth:`~ktch.harmonic.SphericalHarmonicAnalysis.inverse_transform`.
+        Layout: ``[cx_0_0, cx_1_-1, ..., cy_0_0, ..., cz_0_0, ...]``
+        (axis-major, then by degree and order).
+    """
+    if not isinstance(spharmpdm_data, list):
+        spharmpdm_data = [spharmpdm_data]
+
+    n_samples = len(spharmpdm_data)
+    l_max = spharmpdm_data[0].l_max
+    n_coeffs_per_axis = (l_max + 1) ** 2
+
+    result = np.empty((n_samples, 3 * n_coeffs_per_axis))
+    for i, data in enumerate(spharmpdm_data):
+        # SpharmPdmData.coeffs: complex list (SPHARM-PDM convention)
+        # Convert to real SH coefficients
+        stacked = np.vstack(data.coeffs)  # ((l_max+1)^2, 3), complex
+        real_coef = _complex_to_real_sph_coef(stacked)  # float64
+        result[i] = real_coef.T.ravel()
+
+    return result
+
+
+def sha_coeffs_to_spharmpdm(coeffs, specimen_names=None):
+    """Convert SHA flat coefficient vectors to SpharmPdmData objects.
+
+    The input should contain real-valued coefficients from
+    :class:`~ktch.harmonic.SphericalHarmonicAnalysis`.
+    The output ``SpharmPdmData.coeffs`` uses complex coefficients
+    matching the SPHARM-PDM convention.
+
+    Parameters
+    ----------
+    coeffs : np.ndarray of shape (n_samples, 3 * (l_max + 1)**2)
+        Flat SHA coefficient vectors from
+        :meth:`~ktch.harmonic.SphericalHarmonicAnalysis.transform`.
+    specimen_names : list of str, optional
+        Specimen names. Defaults to ``"Specimen_0"``, ``"Specimen_1"``, etc.
+
+    Returns
+    -------
+    spharmpdm_list : list of SpharmPdmData
+        One :class:`SpharmPdmData` per sample.
+
+    Raises
+    ------
+    ValueError
+        If the coefficient vector length is not divisible by 3 or the
+        per-axis count is not a perfect square.
+    """
+    # Lazy import to avoid circular dependency
+    from ._spharm_pdm import SpharmPdmData
+
+    coeffs = np.atleast_2d(coeffs)
+    n_samples, n_features = coeffs.shape
+
+    if n_features % 3 != 0:
+        raise ValueError(
+            f"Coefficient vector length {n_features} is not divisible by 3."
+        )
+
+    n_coeffs_per_axis = n_features // 3
+    l_max_plus_one = np.sqrt(n_coeffs_per_axis)
+    if not l_max_plus_one.is_integer():
+        raise ValueError(
+            f"Per-axis coefficient count {n_coeffs_per_axis} is not a perfect "
+            f"square ((l_max+1)^2)."
+        )
+    l_max = int(l_max_plus_one) - 1
+
+    if specimen_names is None:
+        specimen_names = [f"Specimen_{i}" for i in range(n_samples)]
+
+    spharmpdm_list = []
+    for i in range(n_samples):
+        # Reshape axis-major flat to ((l_max+1)^2, 3), real
+        stacked_real = coeffs[i].reshape(3, n_coeffs_per_axis).T
+        # Convert real SH → complex SH for SpharmPdmData
+        stacked_complex = _real_to_complex_sph_coef(stacked_real)
+
+        # Split into degree-indexed list
+        coef_list = []
+        for l in range(l_max + 1):
+            start = l**2
+            end = (l + 1) ** 2
+            coef_list.append(stacked_complex[start:end])
+
+        spharmpdm_list.append(
+            SpharmPdmData(specimen_name=specimen_names[i], coeffs=coef_list)
+        )
+
+    return spharmpdm_list
+
+
+#
+# SPHARM-PDM format packing (private)
+#
+
+
+def _cvt_spharm_coef_spharmpdm_to_list(
+    coef_spharmpdm: np.ndarray,
+) -> list[np.ndarray]:
+    """Convert SPHARM-PDM format coefficients to list format.
+
+    SPHARM-PDM stores coefficients in a specific order:
+    - For m=0: only real part is stored
+    - For m>0: real and imaginary parts are stored separately
+    - Complex conjugate symmetry is used for m<0
+
+    Parameters
+    ----------
+    coef_spharmpdm : np.ndarray of shape ((lmax+1)^2,3)
+        Flattened array of SPHARM coefficients in SPHARM-PDM format.
+        Contains coefficients for x, y, z coordinates.
+
+    Returns
+    -------
+    coef_list : list of np.ndarray
+        List where coef_list[l] contains coefficients for degree l.
+        Each element is an array of shape (2*l+1, 3) with complex values.
+        The order is m = -l, -l+1, ..., l-1, l.
+
+    Raises
+    ------
+    ValueError
+        If the input array has invalid shape or dimensions.
+    """
+    lmax = int(np.sqrt(coef_spharmpdm.shape[0]) - 1)
+    if coef_spharmpdm.shape != ((lmax + 1) ** 2, 3):
+        raise ValueError(
+            f"Invalid coefficient array shape: expected {((lmax + 1) ** 2, 3)}, got {coef_spharmpdm.shape}"
+        )
+
+    # Convert to list format
+    coef_list = []
+    for l in range(lmax + 1):
+        coef_l = np.zeros((2 * l + 1, 3), dtype=np.complex128)
+
+        for idx, m in enumerate(range(-l, l + 1)):
+            if m == 0:
+                # m=0: only real part
+                coef_l[idx] = coef_spharmpdm[l**2]
+            elif m > 0:
+                # m>0: combine real and imaginary parts
+                real_idx = l**2 + 2 * m - 1
+                imag_idx = l**2 + 2 * m
+                coef_l[idx] = (
+                    coef_spharmpdm[real_idx] - coef_spharmpdm[imag_idx] * 1j
+                ) / 2
+            else:
+                # m<0: use complex conjugate symmetry
+                abs_m = abs(m)
+                real_idx = l**2 + 2 * abs_m - 1
+                imag_idx = l**2 + 2 * abs_m
+                coef_l[idx] = (
+                    ((-1) ** m)
+                    * (coef_spharmpdm[real_idx] + coef_spharmpdm[imag_idx] * 1j)
+                    / 2
+                )
+
+        coef_list.append(coef_l)
+    return coef_list
+
+
+def _cvt_spharm_coef_list_to_spharmpdm(
+    coef_list: list[np.ndarray],
+) -> np.ndarray:
+    """Convert list format coefficients to SPHARM-PDM format.
+
+    Converts complex spherical harmonic coefficients from standard
+    list format to SPHARM-PDM's specific storage format.
+
+    Parameters
+    ----------
+    coef_list : list of np.ndarray
+        List where coef_list[l] contains coefficients for degree l.
+        Each element should have shape (2*l+1,) with complex values.
+        The order is m = -l, -l+1, ..., l-1, l.
+
+    Returns
+    -------
+    coef_spharmpdm : np.ndarray of shape ((lmax+1)^2, 3)
+        Flattened array of coefficients in SPHARM-PDM format.
+        Real and imaginary parts are stored separately.
+
+    Raises
+    ------
+    ValueError
+        If the input list has invalid structure or dimensions.
+
+    Notes
+    -----
+    The conversion uses the complex conjugate symmetry property:
+    Y_l^{-m} = (-1)^m * conj(Y_l^m)
+    """
+    if not isinstance(coef_list, list):
+        raise ValueError("coef_list must be a list")
+
+    if len(coef_list) == 0:
+        raise ValueError("coef_list cannot be empty")
+
+    lmax = len(coef_list) - 1
+
+    # Validate structure of coefficient list
+    for l, coef_l in enumerate(coef_list):
+        expected_len = 2 * l + 1
+        if len(coef_l) != expected_len:
+            raise ValueError(
+                f"coef_list[{l}] has length {len(coef_l)}, expected {expected_len}"
+            )
+
+    # Convert to SPHARM-PDM format
+    coef_spharmpdm = np.zeros(((lmax + 1) ** 2, 3))
+    for l in range(lmax + 1):
+        l_squared = l**2
+
+        # m = 0
+        coef_spharmpdm[l_squared] = coef_list[l][l].real
+
+        # m > 0
+        for m in range(1, l + 1):
+            # Get positive and negative m coefficients
+            coef_pos_m = coef_list[l][m + l]
+            coef_neg_m = coef_list[l][-m + l]
+            sign = (-1) ** m
+
+            # Real part: sum of positive and negative m
+            coef_spharmpdm[l_squared + 2 * m - 1] = (
+                coef_pos_m + sign * coef_neg_m
+            ).real
+
+            # Imaginary part: difference of positive and negative m
+            coef_spharmpdm[l_squared + 2 * m] = (
+                (coef_pos_m - sign * coef_neg_m) * 1j
+            ).real
+
+    return coef_spharmpdm
+
+
+#
 # Coordinate DataFrame conversion utilities
 #
 def convert_coords_df_to_list(df_coords: pd.DataFrame) -> list[np.ndarray]:

--- a/ktch/io/_spharm_pdm.py
+++ b/ktch/io/_spharm_pdm.py
@@ -23,6 +23,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
+from ._converters import _cvt_spharm_coef_spharmpdm_to_list
 from ._protocols import MorphoDataMixin
 
 
@@ -171,147 +172,7 @@ def read_spharmpdm_coef(path: str | Path) -> SpharmPdmData:
     if not lmax_plus_one.is_integer():
         raise ValueError(f"Invalid coefficient count: {n_coef_per_coord} != (lmax+1)^2")
 
-    coef = cvt_spharm_coef_spharmpdm_to_list(coef_array)
+    coef = _cvt_spharm_coef_spharmpdm_to_list(coef_array)
 
     specimen_name = Path(path).stem
     return SpharmPdmData(specimen_name=specimen_name, coeffs=coef)
-
-
-def cvt_spharm_coef_spharmpdm_to_list(
-    coef_spharmpdm: npt.NDArray[np.float64],
-) -> list[npt.NDArray[np.complex128]]:
-    """Convert SPHARM-PDM format coefficients to list format.
-
-    SPHARM-PDM stores coefficients in a specific order:
-    - For m=0: only real part is stored
-    - For m>0: real and imaginary parts are stored separately
-    - Complex conjugate symmetry is used for m<0
-
-    Parameters
-    ----------
-    coef_spharmpdm : np.ndarray of shape ((lmax+1)^2,3)
-        Flattened array of SPHARM coefficients in SPHARM-PDM format.
-        Contains coefficients for x, y, z coordinates.
-
-    Returns
-    -------
-    coef_list : list of np.ndarray
-        List where coef_list[l] contains coefficients for degree l.
-        Each element is an array of shape (2*l+1, 3) with complex values.
-        The order is m = -l, -l+1, ..., l-1, l.
-
-    Raises
-    ------
-    ValueError
-        If the input array has invalid shape or dimensions.
-    """
-    lmax = int(np.sqrt(coef_spharmpdm.shape[0]) - 1)
-    if coef_spharmpdm.shape != ((lmax + 1) ** 2, 3):
-        raise ValueError(
-            f"Invalid coefficient array shape: expected {((lmax + 1) ** 2, 3)}, got {coef_spharmpdm.shape}"
-        )
-
-    # Convert to list format
-    coef_list = []
-    for l in range(lmax + 1):
-        coef_l = np.zeros((2 * l + 1, 3), dtype=np.complex128)
-
-        for idx, m in enumerate(range(-l, l + 1)):
-            if m == 0:
-                # m=0: only real part
-                coef_l[idx] = coef_spharmpdm[l**2]
-            elif m > 0:
-                # m>0: combine real and imaginary parts
-                real_idx = l**2 + 2 * m - 1
-                imag_idx = l**2 + 2 * m
-                coef_l[idx] = (
-                    coef_spharmpdm[real_idx] - coef_spharmpdm[imag_idx] * 1j
-                ) / 2
-            else:
-                # m<0: use complex conjugate symmetry
-                abs_m = abs(m)
-                real_idx = l**2 + 2 * abs_m - 1
-                imag_idx = l**2 + 2 * abs_m
-                coef_l[idx] = (
-                    ((-1) ** m)
-                    * (coef_spharmpdm[real_idx] + coef_spharmpdm[imag_idx] * 1j)
-                    / 2
-                )
-
-        coef_list.append(coef_l)
-    return coef_list
-
-
-def cvt_spharm_coef_list_to_spharmpdm(
-    coef_list: list[npt.NDArray[np.complex128]],
-) -> npt.NDArray[np.float64]:
-    """Convert list format coefficients to SPHARM-PDM format.
-
-    Converts complex spherical harmonic coefficients from standard
-    list format to SPHARM-PDM's specific storage format.
-
-    Parameters
-    ----------
-    coef_list : list of np.ndarray
-        List where coef_list[l] contains coefficients for degree l.
-        Each element should have shape (2*l+1,) with complex values.
-        The order is m = -l, -l+1, ..., l-1, l.
-
-    Returns
-    -------
-    coef_spharmpdm : np.ndarray of shape ((lmax+1)^2, 3)
-        Flattened array of coefficients in SPHARM-PDM format.
-        Real and imaginary parts are stored separately.
-
-    Raises
-    ------
-    ValueError
-        If the input list has invalid structure or dimensions.
-
-    Notes
-    -----
-    The conversion uses the complex conjugate symmetry property:
-    Y_l^{-m} = (-1)^m * conj(Y_l^m)
-    """
-    if not isinstance(coef_list, list):
-        raise ValueError("coef_list must be a list")
-
-    if len(coef_list) == 0:
-        raise ValueError("coef_list cannot be empty")
-
-    lmax = len(coef_list) - 1
-
-    # Validate structure of coefficient list
-    for l, coef_l in enumerate(coef_list):
-        expected_len = 2 * l + 1
-        if len(coef_l) != expected_len:
-            raise ValueError(
-                f"coef_list[{l}] has length {len(coef_l)}, expected {expected_len}"
-            )
-
-    # Convert to SPHARM-PDM format
-    coef_spharmpdm = np.zeros(((lmax + 1) ** 2, 3))
-    for l in range(lmax + 1):
-        l_squared = l**2
-
-        # m = 0
-        coef_spharmpdm[l_squared] = coef_list[l][l].real
-
-        # m > 0
-        for m in range(1, l + 1):
-            # Get positive and negative m coefficients
-            coef_pos_m = coef_list[l][m + l]
-            coef_neg_m = coef_list[l][-m + l]
-            sign = (-1) ** m
-
-            # Real part: sum of positive and negative m
-            coef_spharmpdm[l_squared + 2 * m - 1] = (
-                coef_pos_m + sign * coef_neg_m
-            ).real
-
-            # Imaginary part: difference of positive and negative m
-            coef_spharmpdm[l_squared + 2 * m] = (
-                (coef_pos_m - sign * coef_neg_m) * 1j
-            ).real
-
-    return coef_spharmpdm

--- a/ktch/io/tests/test_converters.py
+++ b/ktch/io/tests/test_converters.py
@@ -1,16 +1,24 @@
 """Tests for format conversion functions."""
 
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import pytest
 
+from ktch.io import read_spharmpdm_coef
 from ktch.io._converters import (
-    convert_coords_df_to_list,
+    _cvt_spharm_coef_list_to_spharmpdm,
+    _cvt_spharm_coef_spharmpdm_to_list,
     convert_coords_df_to_df_sklearn_transform,
+    convert_coords_df_to_list,
     efa_coeffs_to_nef,
     nef_to_efa_coeffs,
+    sha_coeffs_to_spharmpdm,
+    spharmpdm_to_sha_coeffs,
 )
 from ktch.io._nef import NefData
+from ktch.io._spharm_pdm import SpharmPdmData
 
 
 def _make_nef(n_harmonics=3, seed=42):
@@ -20,7 +28,9 @@ def _make_nef(n_harmonics=3, seed=42):
     return NefData(specimen_name="S1", coeffs=coeffs)
 
 
-# --- nef_to_efa_coeffs ---
+#
+# nef_to_efa_coeffs
+#
 
 
 class TestNefToEfaCoeffs:
@@ -105,7 +115,10 @@ class TestCoordConversion:
             [("A", 0), ("A", 1), ("A", 2), ("B", 0), ("B", 1), ("B", 2)],
             names=["specimen_id", "coord_id"],
         )
-        data = {"x": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], "y": [7.0, 8.0, 9.0, 10.0, 11.0, 12.0]}
+        data = {
+            "x": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "y": [7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
+        }
         return pd.DataFrame(data, index=index)
 
     def test_convert_coords_df_to_list(self):
@@ -124,3 +137,126 @@ class TestCoordConversion:
         assert result.shape == (2, 6)  # 2 specimens, 3 coords * 2 dims
         assert "A" in result.index
         assert "B" in result.index
+
+
+#
+# SPHARM-PDM format packing
+#
+
+
+class TestSpharmCoefFormatPacking:
+    @pytest.fixture()
+    def spharmpdm_data(self):
+        path = Path(__file__).parent / "data" / "andesred_07_allSegments_SPHARM.coef"
+        return read_spharmpdm_coef(path)
+
+    def test_roundtrip_list(self, spharmpdm_data):
+        """list -> spharmpdm -> list produces identical coefficients."""
+        coef_spharmpdm = _cvt_spharm_coef_list_to_spharmpdm(spharmpdm_data.coeffs)
+        coef_list_rt = _cvt_spharm_coef_spharmpdm_to_list(coef_spharmpdm)
+
+        for l in range(len(spharmpdm_data.coeffs)):
+            np.testing.assert_array_almost_equal(
+                spharmpdm_data.coeffs[l], coef_list_rt[l]
+            )
+
+    def test_roundtrip_spharmpdm(self, spharmpdm_data):
+        """spharmpdm -> list -> spharmpdm produces identical array."""
+        coef_pdm = _cvt_spharm_coef_list_to_spharmpdm(spharmpdm_data.coeffs)
+        coef_list_rt = _cvt_spharm_coef_spharmpdm_to_list(coef_pdm)
+        coef_pdm_rt = _cvt_spharm_coef_list_to_spharmpdm(coef_list_rt)
+
+        np.testing.assert_array_almost_equal(coef_pdm, coef_pdm_rt)
+
+
+# --- SPHARM-PDM <-> SHA bridge converters ---
+
+
+class TestSpharmpdmToShaCoeffs:
+    @pytest.fixture()
+    def spharmpdm_data(self):
+        path = Path(__file__).parent / "data" / "andesred_07_allSegments_SPHARM.coef"
+        return read_spharmpdm_coef(path)
+
+    def test_output_shape(self, spharmpdm_data):
+        result = spharmpdm_to_sha_coeffs(spharmpdm_data)
+        l_max = spharmpdm_data.l_max
+        assert result.shape == (1, 3 * (l_max + 1) ** 2)
+
+    def test_output_dtype(self, spharmpdm_data):
+        result = spharmpdm_to_sha_coeffs(spharmpdm_data)
+        assert result.dtype == np.float64
+
+    def test_layout_lmax0_real(self):
+        """l=0 coefficients: m=0 is real, same in complex and real basis."""
+        # For l=0, m=0: a_0^0 = Re(c_0^0). Use real c_0^0.
+        coeffs = [
+            np.array([[1.0 + 0j, 3.0 + 0j, 5.0 + 0j]]),  # l=0
+        ]
+        data = SpharmPdmData(specimen_name="T", coeffs=coeffs)
+        result = spharmpdm_to_sha_coeffs(data)
+
+        assert result.shape == (1, 3)
+        assert result.dtype == np.float64
+        np.testing.assert_allclose(result[0], [1.0, 3.0, 5.0])
+
+    def test_roundtrip_preserves_shape(self, spharmpdm_data):
+        """SHA flat → SpharmPdmData → SHA flat round-trip."""
+        sha_flat = spharmpdm_to_sha_coeffs(spharmpdm_data)
+        rt_list = sha_coeffs_to_spharmpdm(
+            sha_flat, specimen_names=[spharmpdm_data.specimen_name]
+        )
+        sha_flat_rt = spharmpdm_to_sha_coeffs(rt_list)
+        np.testing.assert_allclose(sha_flat_rt, sha_flat, atol=1e-12)
+
+    def test_batch(self, spharmpdm_data):
+        result = spharmpdm_to_sha_coeffs([spharmpdm_data, spharmpdm_data])
+        l_max = spharmpdm_data.l_max
+        assert result.shape == (2, 3 * (l_max + 1) ** 2)
+        np.testing.assert_array_equal(result[0], result[1])
+
+
+class TestShaCoeffsToSpharmpdm:
+    @pytest.fixture()
+    def spharmpdm_data(self):
+        path = Path(__file__).parent / "data" / "andesred_07_allSegments_SPHARM.coef"
+        return read_spharmpdm_coef(path)
+
+    def test_roundtrip(self, spharmpdm_data):
+        """SpharmPdmData -> SHA flat -> SpharmPdmData round-trip."""
+        sha_flat = spharmpdm_to_sha_coeffs(spharmpdm_data)
+        result_list = sha_coeffs_to_spharmpdm(
+            sha_flat, specimen_names=[spharmpdm_data.specimen_name]
+        )
+
+        assert len(result_list) == 1
+        result = result_list[0]
+        assert result.specimen_name == spharmpdm_data.specimen_name
+        assert result.l_max == spharmpdm_data.l_max
+        # SpharmPdmData.coeffs remains complex (format-faithful)
+        for l in range(result.l_max + 1):
+            assert result.coeffs[l].dtype == np.complex128
+            np.testing.assert_array_almost_equal(
+                result.coeffs[l], spharmpdm_data.coeffs[l]
+            )
+
+    def test_default_specimen_names(self):
+        coeffs = np.zeros((2, 3))  # l_max=0, 2 samples
+        result = sha_coeffs_to_spharmpdm(coeffs)
+        assert result[0].specimen_name == "Specimen_0"
+        assert result[1].specimen_name == "Specimen_1"
+
+    def test_invalid_length_not_divisible_by_3(self):
+        with pytest.raises(ValueError, match="not divisible by 3"):
+            sha_coeffs_to_spharmpdm(np.zeros((1, 5)))
+
+    def test_invalid_length_not_perfect_square(self):
+        with pytest.raises(ValueError, match="not a perfect square"):
+            sha_coeffs_to_spharmpdm(np.zeros((1, 6)))  # 6/3=2, not a square
+
+    def test_single_sample_1d_input(self, spharmpdm_data):
+        """1D input is promoted to 2D."""
+        sha_flat = spharmpdm_to_sha_coeffs(spharmpdm_data)
+        result = sha_coeffs_to_spharmpdm(sha_flat[0])
+        assert len(result) == 1
+        assert result[0].l_max == spharmpdm_data.l_max

--- a/ktch/io/tests/test_spharm_pdm.py
+++ b/ktch/io/tests/test_spharm_pdm.py
@@ -4,11 +4,7 @@ from pathlib import Path
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 
-from ktch.io import (
-    cvt_spharm_coef_list_to_spharmpdm,
-    cvt_spharm_coef_spharmpdm_to_list,
-    read_spharmpdm_coef,
-)
+from ktch.io import read_spharmpdm_coef
 from ktch.io._protocols import MorphoData
 from ktch.io._spharm_pdm import SpharmPdmData
 
@@ -49,30 +45,6 @@ def test_read_spharmpdm_coef_m_0():
     assert data.coeffs[0][0, 2] == coef_list_raw[0][2]
     for l in range(1, l_max + 1):
         assert_array_almost_equal(data.coeffs[l][l], coef_list_raw[l**2])
-
-
-def test_spharm_coef_roundtrip_list():
-    """list -> spharmpdm -> list produces identical coefficients."""
-    path = Path(__file__).parent / "data" / "andesred_07_allSegments_SPHARM.coef"
-    data = read_spharmpdm_coef(path)
-
-    coef_spharmpdm = cvt_spharm_coef_list_to_spharmpdm(data.coeffs)
-    coef_list_rt = cvt_spharm_coef_spharmpdm_to_list(coef_spharmpdm)
-
-    for l in range(len(data.coeffs)):
-        assert_array_almost_equal(data.coeffs[l], coef_list_rt[l])
-
-
-def test_spharm_coef_roundtrip_spharmpdm():
-    """spharmpdm -> list -> spharmpdm produces identical array."""
-    path = Path(__file__).parent / "data" / "andesred_07_allSegments_SPHARM.coef"
-    data = read_spharmpdm_coef(path)
-
-    coef_pdm = cvt_spharm_coef_list_to_spharmpdm(data.coeffs)
-    coef_list_rt = cvt_spharm_coef_spharmpdm_to_list(coef_pdm)
-    coef_pdm_rt = cvt_spharm_coef_list_to_spharmpdm(coef_list_rt)
-
-    assert_array_almost_equal(coef_pdm, coef_pdm_rt)
 
 
 # --- SpharmPdmData protocol and methods ---


### PR DESCRIPTION
## Summary

- Consolidate converters into `io/_converters.py`, privatize format packing functions
- Add `spharmpdm_to_sha_coeffs` / `sha_coeffs_to_spharmpdm` (closes #139)
- Convert SHA to real spherical harmonic basis (output: `float64`)
- Add `doc/explanation/io.md`